### PR TITLE
feat: :sparkles: github ActionでECSにデプロイされる機能を実装

### DIFF
--- a/.github/ecs/task-def.template.json
+++ b/.github/ecs/task-def.template.json
@@ -1,0 +1,24 @@
+{
+    "family": "lighthouse-contest-${STUDENT_ID}",
+    "networkMode": "awsvpc",
+    "containerDefinitions": [
+      {
+        "name": "${CONTAINER_NAME}-${STUDENT_ID}",
+        "image": "REPLACED_BY_GITHUB_ACTION",
+        "memory": 512,
+        "cpu": 256,
+        "essential": true,
+        "portMappings": [
+          {
+            "containerPort": 80,
+            "hostPort": 80,
+            "protocol": "tcp"
+          }
+        ]
+      }
+    ],
+    "requiresCompatibilities": ["FARGATE"],
+    "cpu": "256",
+    "memory": "512",
+    "executionRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/ecsTaskExecutionRole"
+}

--- a/.github/workflows/deploy.template.yml
+++ b/.github/workflows/deploy.template.yml
@@ -1,0 +1,65 @@
+name: Deploy to ECS Fargate
+
+# main/0にpull_requestがcloseされたときに実行
+# マージの是非は後ほどフィルタリング
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main/${STUDENT_ID}
+
+# 環境変数
+env:
+  AWS_REGION: ${AWS_REGION}
+  ECR_REPOSITORY: ${ECR_REPOSITORY}
+  ECS_CLUSTER: ${ECS_CLUSTER}
+  ECS_SERVICE: ${ECS_SERVICE}-${STUDENT_ID}
+  CONTAINER_NAME: ${CONTAINER_NAME}-${STUDENT_ID}
+
+jobs:
+	# deploy job
+  deploy:
+	  # PRがマージされた時のみ実行
+    if: github.event.pull_request.merged == true
+    # github Actionの仮想実行マシーンの指定 ubuntu最新版
+    runs-on: ubuntu-latest
+		# 順次実行される処理のリスト
+    steps:
+	    # 仮想マシーンにリポジトリをダウンロード
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+			# AWS の認証情報を設定
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::${AWS_ACCOUNT_ID}:role/${IAM_ROLE_NAME}
+          aws-region: ${{ env.AWS_REGION }}
+
+			# ECR にログイン
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+			# Docker ビルド & プッシュ
+      - name: Build, tag, and push image to ECR
+        run: |
+          docker build -t ${{ steps.login-ecr.outputs.registry }}/tuning-contest-${STUDENT_ID}:latest .
+          docker push ${{ steps.login-ecr.outputs.registry }}/tuning-contest-${STUDENT_ID}:latest
+
+      # テンプレートを元に、使用する Docker イメージ名だけ差し替えて、新しいタスク定義を作成する
+      - name: Render ECS task definition
+        id: render-task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: .github/ecs/task-def.json
+          container-name: ${{ env.CONTAINER_NAME }}
+          image: ${{ steps.login-ecr.outputs.registry }}/tuning-contest-${STUDENT_ID}:latest
+
+      # ECSでデプロイ
+      - name: Deploy to ECS
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          cluster: ${{ env.ECS_CLUSTER }}
+          service: ${{ env.ECS_SERVICE }}
+          task-definition: ${{ steps.render-task-def.outputs.task-definition }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+.github/workflows/deploy.yml
+.github/ecs/task-def.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+include .env
+
+.PHONY: init_mac generate-deploy
+
+init_mac:
+	bash -c "brew install gettext && brew link --force gettext && which envsubst && envsubst --version"
+
+generate-deploy:
+	set -o allexport && source .env && envsubst < .github/workflows/deploy.template.yml > .github/workflows/deploy.yml
+	set -o allexport && source .env && envsubst < .github/ecs/task-def.template.json > .github/ecs/task-def.json


### PR DESCRIPTION
# Why
- main/学生番号のbranchにマージしたらデプロイされるようにしたい

# What
- makeで.github/ecs/task-def.jsonと.github/workflows/deploy.ymlが生成されるようにする
- 上記二つのファイルを使用してGithubActionがデプロイまでを行う

# Result
- 動作未確認