### PR TITLE
fix: :sparkles: 参加者のmain branchの名称を修正

### DIFF
--- a/.github/workflows/deploy.template.yml
+++ b/.github/workflows/deploy.template.yml
@@ -1,12 +1,12 @@
 name: Deploy to ECS Fargate
 
-# main/0にpull_requestがcloseされたときに実行
+# ${{ secrets.STUDENT_ID }}/mainにpull_requestがcloseされたときに実行
 # マージの是非は後ほどフィルタリング
 on:
   pull_request:
     types: [closed]
     branches:
-      - main/${{ secrets.STUDENT_ID }}
+      - ${{ secrets.STUDENT_ID }}/main
 
 # 環境変数
 env:


### PR DESCRIPTION
# Why
- 学生番号/mainのbranchにマージしたらデプロイされるようにしたい

# What
-gitはbranchを.git/refs/heads/以下にファイルパスとして保存するため、mainが存在する状態でmain/1のようなブランチを作成すると元からあるmainファイルとmain/1で作成しようとするmainディレクトリの名前が衝突してしまい、ブランチの作成に失敗するから

# Result
- 学生番号/mainへのマージを検出