### PR TITLE
feat: :sparkles: githubのシークレットをローカルから設定する機能を追加

### DIFF
--- a/scripts/sync_github_secrets.sh
+++ b/scripts/sync_github_secrets.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# デフォルトの env ファイル名
+ENV_FILE="../.env.github.secrets"
+REPO=""
+
+# ヘルプ表示関数
+tmp_usage() {
+  cat <<EOF
+Usage: $0 -r owner/repo [-f env_file]
+
+Options:
+  -r  GitHub repository in owner/repo format (required)
+  -f  Path to .env file (default: $ENV_FILE)
+  -h  Show this help message
+EOF
+  exit 1
+}
+
+# 引数解析
+while getopts ":r:f:h" opt; do
+  case ${opt} in
+    r) REPO=$OPTARG ;; 
+    f) ENV_FILE=$OPTARG ;; 
+    h) tmp_usage ;; 
+    *) tmp_usage ;; 
+  esac
+done
+
+# リポジトリ必須チェック
+if [[ -z "$REPO" ]]; then
+  echo "Error: repository (-r) is required."
+  tmp_usage
+fi
+
+# gh CLI の存在チェック
+if ! command -v gh >/dev/null 2>&1; then
+  echo "Error: GitHub CLI (gh) not found. Please install: https://cli.github.com/"
+  exit 1
+fi
+
+# 認証実行
+echo "→ Authenticating with GitHub CLI..."
+gh auth login --hostname github.com
+
+# 認証状態確認
+if ! gh auth status >/dev/null 2>&1; then
+  echo "Error: GitHub CLI authentication failed."
+  exit 1
+fi
+
+# env ファイル存在チェック
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Error: env file '$ENV_FILE' not found."
+  exit 1
+fi
+
+echo "→ Syncing secrets from '$ENV_FILE' to '$REPO'..."
+while IFS='=' read -r name value || [[ -n "$name" ]]; do
+  # コメント行または空行をスキップ
+  [[ "$name" =~ ^\s*# ]] && continue
+  [[ -z "$name" ]] && continue
+
+  # 前後の空白をトリム
+  name=$(echo -n "$name" | xargs)
+  value=$(echo -n "$value" | xargs)
+
+  echo "  • Setting secret: $name"
+  gh secret set "$name" -R "$REPO" --body "$value"
+done < "$ENV_FILE"
+
+echo "All secrets synced successfully."


### PR DESCRIPTION
# Why
- 計測対象のリポジトリにシークレットを設定しなくてはならない。これは計測対象のリポジトリに配置するgithub actionが本リポジトリにアクセスするために使用する。
- 本プロジェクトはなるべくmakeコマンドで全てが完結するようにしたいためローカルからシークレットをpushする機能が欲しい。

# What
- sync_github_secrets.sh というログインからpushまでを自動で行うスクリプトを作成
- 認証にはOAuth(ブラウザ)を使用

# Result
以下コマンドで`.env.github.secrets.lighthous`に設定された変数が設定できることをブラウザで確認できた。
```
./sync_github_secrets.sh -r daikonoisii/web-tuning-contest -f ../.env.github.secrets.lighthous
```
