### PR TITLE
fix: :zap: Configure AWS credentialsで認証に失敗する問題を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
   repository_dispatch:
     types: [run-tuning]
 
+permissions:
+  id-token: write
+
 # 環境変数
 env:
   STUDENT_ID: ${{ github.event.client_payload.STUDENT_ID }}


### PR DESCRIPTION
# Why

* GitHub ActionsのAWS認証設定で、OIDCトークン取得の権限不備により、`Credentials could not be loaded`エラーが発生

# What

* `.github/workflows/deploy.yml`の`permissions`項目に`id-token: write`を追加し、OIDCトークンを発行

# Result

* 動作未確認