### PR TITLE
fix: :recycle: GIthub actionの一部userのバージョンを変更

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,7 +84,7 @@ jobs:
 
       # ECSでデプロイ
       - name: Deploy to ECS
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:
           cluster: ${{ env.ECS_CLUSTER }}
           service: ${{ env.ECS_SERVICE }}


### PR DESCRIPTION
# Why

* GitHub Actionsのaws-actions/amazon-ecs-deploy-task-definition@v1が使用しているJavascriptのバージョンのサポートが終了している警告が出ていた

# What
- aws-actions/amazon-ecs-deploy-task-definition@v1 -> v2

# Result
- 動作未確認
