### PR TITLE
feat: :sparkles: インバウンドルールを作成する機能を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,9 @@ init_admin:
 		make --no-print-directory -s crate-security-group)); \
 	SG_LAMBDA=$${VARS[0]}; \
 	SG_ECS=$${VARS[1]}; \
+	SG_LAMBDA=$$SG_LAMBDA \
+	SG_ECS=$$SG_ECS \
+	make --no-print-directory -s create-security-role; \
 	$(MAKE) create-ecs-cluster
 
 thumbprint:
@@ -193,3 +196,10 @@ crate-security-group:
 		--group-name $(SG_ECS_NAME) --description "ECS inbound from Lambda" \
 		--vpc-id $$VPC_ID --query 'GroupId' --output text); \
 	echo "$$SG_LAMBDA $$SG_ECS"
+
+create-security-role:
+	. ./scripts/assume-role.sh \
+		--role-name $(VPC_ROLE_NAME) \
+		--profile admin; \
+	aws ec2 authorize-security-group-ingress --group-id $$SG_ECS \
+		--protocol tcp --port $(APP_PORT) --source-group $$SG_LAMBDA; \


### PR DESCRIPTION
# Why

* Lambda 関数から ECS 上のコンテナへ TCP 通信を行うためには、ECS 側のセキュリティグループ（SG\_ECS）に対して、Lambda 用のセキュリティグループ（SG\_LAMBDA）を送信元とするインバウンドルールを設定する必要がある。これがないとコンテナがリクエストを受け付けられない。
* `make` コマンド一発でインフラを構築・更新できるよう、自動化スクリプト内でインバウンドルールの設定も完結させたい。

# What

* `init_admin` ターゲットで取得した `SG_LAMBDA`／`SG_ECS` の環境変数を、`create-security-role` ターゲットへ正しく渡すよう Makefile を修正
* Makefile に `create-security-role` ターゲットを追加し、以下の AWS CLI コマンドでインバウンドルールを作成

  ```bash
  aws ec2 authorize-security-group-ingress \
    --group-id $SG_ECS \
    --protocol tcp \
    --port $(APP_PORT) \
    --source-group $SG_LAMBDA
  ```

  これにより、Lambda 用 SG から ECS 用 SG への TCP 通信がアプリケーションポートで許可されるようになる
# Result

以下の手順で、ECS 側セキュリティグループにインバウンドルールが追加されていることを確認できた。

```make
# Makefile
debug:
	VARS=($$(make --no-print-directory -s create-vpc)); \
	VPC_ID=$${VARS[0]}; \
	SUBNET1_ID=$${VARS[1]}; \
	SUBNET2_ID=$${VARS[2]}; \
	VARS=($$( \
		VPC_ID=$${VPC_ID} \
		make --no-print-directory -s crate-security-group)); \
	SG_LAMBDA=$${VARS[0]}; \
	SG_ECS=$${VARS[1]}; \
	echo "$$SG_LAMBDA $$SG_ECS"; \
	SG_LAMBDA=$$SG_LAMBDA \
	SG_ECS=$$SG_ECS \
	make --no-print-directory -s create-security-role; \
```
```bash
make debug
```

出力結果に `FromPort` / `ToPort` として `$(APP_PORT)`、`UserIdGroupPairs` に `GroupId` が `SG_LAMBDA` のエントリが含まれていることをブラウザおよび CLI で確認できた。