### PR TITLE
feat: ⚡ ECSサービスを作成する機能を追加

### DIFF
--- a/.github/ecs/task-def.template.json
+++ b/.github/ecs/task-def.template.json
@@ -1,10 +1,10 @@
 {
-    "family": "lighthouse-contest-${STUDENT_ID}",
+    "family": "${FAMILY_NAME}-${STUDENT_ID}",
     "networkMode": "awsvpc",
     "containerDefinitions": [
       {
         "name": "${CONTAINER_NAME}",
-        "image": "REPLACED_BY_GITHUB_ACTION",
+        "image": "public.ecr.aws/${ECR_REPOSITORY}-${STUDENT_ID}",
         "memory": 512,
         "cpu": 256,
         "essential": true,
@@ -17,7 +17,15 @@
         ],
         "entryPoint": ${ENTRY_POINT_COMMAND},
         "command": ${START_COMMAND},
-        "environment": ${ENVIRONMENT_COMMAND}
+        "environment": ${ENVIRONMENT_COMMAND},
+        "logConfiguration": {
+          "logDriver": "awslogs",
+          "options": {
+            "awslogs-group":  "/ecs/work-space-${STUDENT_ID}",
+            "awslogs-region": "${MY_AWS_REGION}",
+            "awslogs-stream-prefix": "work-space-${STUDENT_ID}"
+          }
+        }
       }
     ],
     "requiresCompatibilities": ["FARGATE"],

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 assume-role-config.json
 lighthouse-flows-generator/output.json
 work_space/*
+.github/ecs/task-def.json

--- a/Makefile
+++ b/Makefile
@@ -162,15 +162,6 @@ create-ecs-cluster:
 	  echo "✅ Cluster created."; \
 	fi
 
-test:
-	. ./scripts/assume-role.sh \
-		--role-name $(ECS_ROLE_NAME) \
-		--profile admin; \
-	aws ecs describe-clusters \
-		--clusters $(ECS_CLUSTER) \
-		--region $(MY_AWS_REGION) \
-		--query "clusters[?status=='ACTIVE'].clusterName" \
-		--output text
 
 create-vpc:
 	. ./scripts/assume-role.sh \

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,6 @@ init_admin:
 	brew install gh
 	./scripts/sync_github_secrets.sh -r ${LIGHTHOUSE_ORG}/${LIGHTHOUSE_REPOSITORY_NAME} -f ./.env.github.secrets.lighthouse
 	./scripts/sync_github_secrets.sh -r ${WORK_SPACE_ORG}/${WORK_SPACE_REPOSITORY_NAME} -f ./.env.github.secrets.work_space
-	$(MAKE) create-oidc-provider
 	if ! RESPONSE=$$(make --no-print-directory -s create-oidc-provider 2>&1); then \
 	  if echo "$$RESPONSE" | grep -q 'EntityAlreadyExists'; then \
 	    echo "OIDCプロバイダーは既に存在しています。処理を継続します。"; \

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ create-ecr-repository:
 
 create-ecs-cluster:
 	. ./scripts/assume-role.sh \
-		--role-name $(ECS_ROLE_NAME) \
+		--role-name $(ECS_ADMIN_ROLE_NAME) \
 		--profile admin; \
 	if aws ecs describe-clusters \
 	      --clusters $(ECS_CLUSTER) \

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ create-ecr-repository:
 	. ./scripts/assume-role.sh \
 			--role-name $(ECR_ROLE_NAME) \
 			--profile participant; \
-	aws ecr create-repository --repository-name $(ECR_REPOSITORY)-$(STUDENT_ID) --region ap-northeast-1
+	aws ecr create-repository --repository-name $(ECR_REPOSITORY)-$(STUDENT_ID) --region $(MY_AWS_REGION)
 
 create-ecs-cluster:
 	. ./scripts/assume-role.sh \

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,14 @@ init_mac:
 	git add ./.github/workflows/deploy.yml; \
 	git commit -m "feat: :sparkles: create github action branch $(STUDENT_ID)/main"; \
 	git push -u origin $(STUDENT_ID)/main
-	$(MAKE) create-ecr-repository
+	if ! RESPONSE=$$(make --no-print-directory -s create-ecr-repository 2>&1); then \
+	  if echo "$$RESPONSE" | grep -q 'RepositoryAlreadyExistsException'; then \
+	    echo "ECRリポジトリは既に存在しています。処理を継続します。"; \
+	  else \
+	    echo "$$RESPONSE"; \
+	    exit 1; \
+	  fi; \
+	fi; \
 	make --no-print-directory -s register-task-definition
 	@echo "✅ finish"
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 ifneq ($(filter create-ecr-repository \
 				create-ecs-service \
 				init_mac \

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ init_admin:
 	SG_ECS=$${VARS[1]}; \
 	SG_LAMBDA=$$SG_LAMBDA \
 	SG_ECS=$$SG_ECS \
-	make --no-print-directory -s create-security-role; \
+	make --no-print-directory -s create-security-rule; \
 	$(MAKE) create-ecs-cluster
 
 thumbprint:
@@ -162,7 +162,6 @@ create-ecs-cluster:
 	  echo "✅ Cluster created."; \
 	fi
 
-
 create-vpc:
 	. ./scripts/assume-role.sh \
 			--role-name $(VPC_ROLE_NAME) \
@@ -188,7 +187,7 @@ crate-security-group:
 		--vpc-id $$VPC_ID --query 'GroupId' --output text); \
 	echo "$$SG_LAMBDA $$SG_ECS"
 
-create-security-role:
+create-security-rule:
 	. ./scripts/assume-role.sh \
 		--role-name $(VPC_ROLE_NAME) \
 		--profile admin; \

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,14 @@ init_admin:
 	./scripts/sync_github_secrets.sh -r ${LIGHTHOUSE_ORG}/${LIGHTHOUSE_REPOSITORY_NAME} -f ./.env.github.secrets.lighthouse
 	./scripts/sync_github_secrets.sh -r ${WORK_SPACE_ORG}/${WORK_SPACE_REPOSITORY_NAME} -f ./.env.github.secrets.work_space
 	$(MAKE) create-oidc-provider
+	if ! RESPONSE=$$(make --no-print-directory -s create-oidc-provider 2>&1); then \
+	  if echo "$$RESPONSE" | grep -q 'EntityAlreadyExists'; then \
+	    echo "OIDCプロバイダーは既に存在しています。処理を継続します。"; \
+	  else \
+	    echo "$$RESPONSE"; \
+	    exit 1; \
+	  fi; \
+	fi; \
 	VARS=($$(MAKE --no-print-directory -s create-vpc)); \
 	VPC_ID=$${VARS[0]}; \
 	SUBNET1_ID=$${VARS[1]}; \

--- a/lighthouse-flows-generator/serverless.yml
+++ b/lighthouse-flows-generator/serverless.yml
@@ -37,6 +37,15 @@ provider:
             - ecr:GetRepositoryPolicy
           Resource:
             - arn:aws:ecr:${env:MY_AWS_REGION}:${env:AWS_ACCOUNT_ID}:repository/serverless-lighthouse-flows-generator-dev
+        - Effect: Allow
+          Action:
+            - ec2:CreateNetworkInterface
+            - ec2:DescribeNetworkInterfaces
+            - ec2:DeleteNetworkInterface
+            - ec2:DescribeSecurityGroups
+            - ec2:DescribeSubnets
+            - ec2:DescribeVpcs
+          Resource: "*"
 
 
 functions:

--- a/scripts/push_aws_parameters.sh
+++ b/scripts/push_aws_parameters.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# デフォルト値
+ENV_FILE=""
+PARAM_PREFIX="/myapp"
+SHOW_HELP=false
+
+# ヘルプ関数
+print_usage() {
+  cat <<EOF
+Usage: $0 -f <env_file> [--prefix /path/prefix]
+
+Options:
+  -f        Path to .env file (required)
+  --prefix  SSM parameter path prefix (default: /myapp)
+  -h        Show this help message
+
+Example:
+  $0 -f ./secrets.env --prefix /lighthouse/dev
+EOF
+  exit 1
+}
+
+# 引数解析
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -f)
+      ENV_FILE="$2"
+      shift 2
+      ;;
+    --prefix)
+      PARAM_PREFIX="$2"
+      shift 2
+      ;;
+    -h|--help)
+      print_usage
+      ;;
+    *)
+      echo "Unknown option: $1"
+      print_usage
+      ;;
+  esac
+done
+
+# 引数チェック
+if [[ -z "$ENV_FILE" ]]; then
+  echo "❌ Error: -f <env_file> is required."
+  print_usage
+fi
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "❌ Error: env file not found: $ENV_FILE"
+  exit 1
+fi
+
+echo "📦 Uploading parameters from: $ENV_FILE"
+echo "📁 Using prefix: $PARAM_PREFIX"
+
+while IFS='=' read -r key value || [[ -n "$key" ]]; do
+  # 空行・コメント行をスキップ
+  [[ "$key" =~ ^\s*# ]] && continue
+  [[ -z "$key" ]] && continue
+
+  # 空白を除去
+  key=$(echo -n "$key" | xargs)
+  value=$(echo -n "$value" | xargs)
+
+  # 型判定
+  if [[ "$key" == *_SECURE ]]; then
+    param_key="${key%_SECURE}"
+    param_type="SecureString"
+  elif [[ "$value" == *,* ]]; then
+    param_key="$key"
+    param_type="StringList"
+  else
+    param_key="$key"
+    param_type="String"
+  fi
+
+  # フルパス作成
+  full_param_name="${PARAM_PREFIX}/${param_key}"
+
+  echo "  → Registering: ${full_param_name} (${param_type})"
+
+  aws ssm put-parameter \
+    --name "$full_param_name" \
+    --value "$value" \
+    --type "$param_type" \
+    --overwrite
+done < "$ENV_FILE"
+
+echo "✅ All parameters uploaded successfully."


### PR DESCRIPTION
# Why

* ECSサービスの作成をMakefileから自動化することで、参加者ごとにコンテナを立ち上げる手順を一元化したい。
* 既存のOIDCプロバイダーやECRリポジトリがあってもスクリプトが途中で止まらないようにしたい。

# What

* `task-def.template.json`に`logConfiguration`セクションを追加
* Makefileに以下新規ターゲット／機能を追加

  * `register-task-definition`: `aws ecs register-task-definition`でタスク定義を登録
  * `create-ecs-service`: 指定のクラスター／タスク定義でECSサービスを作成
  * `push-parameter`: VPC IDなどをAWS Parameter Storeへプッシュ
  * `get-parameter-by-path`: パス指定でParameter Storeから値を取得
* 既存処理の改善

  * 不要な`create-oidc-provider`呼び出しやmakeコマンドを削除
  * OIDCプロバイダーやECRリポジトリが既に存在しても処理を継続
  * Makefile内のシェルを`bash`に変更し、環境変数展開を安定化
  * ハードコーディングされていたAWSリージョンを変数化

# Result

以下コマンドを実行すると、タスク定義の登録からECSサービスの作成までが自動で完了し、AWSコンソールまたはCLIでサービス名が確認できることをブラウザで確認した。

```bash
 make init_mac
```
※既に、`make init_admin`が完了している状態

しかし、ECRからイメージを取得できていないため、別途施釉性が必要