### PR TITLE
fear: zap: ECRからイメージを取得できるように環境を構築する

### DIFF
--- a/.github/ecs/task-def.template.json
+++ b/.github/ecs/task-def.template.json
@@ -4,7 +4,7 @@
     "containerDefinitions": [
       {
         "name": "${CONTAINER_NAME}",
-        "image": "public.ecr.aws/${ECR_REPOSITORY}-${STUDENT_ID}",
+        "image": "${AWS_ACCOUNT_ID}.dkr.ecr.${MY_AWS_REGION}.amazonaws.com/${ECR_REPOSITORY}-${STUDENT_ID}:latest",
         "memory": 512,
         "cpu": 256,
         "essential": true,

--- a/Makefile
+++ b/Makefile
@@ -242,8 +242,16 @@ create-security-rule:
 	. ./scripts/assume-role.sh \
 		--role-name $(VPC_ROLE_NAME) \
 		--profile admin; \
-	aws ec2 authorize-security-group-ingress --group-id $$SG_ECS \
-		--protocol tcp --port $(APP_PORT) --source-group $$SG_LAMBDA; \
+	aws ec2 authorize-security-group-ingress \
+		--group-id $$SG_ECS \
+		--protocol tcp \
+		--port $(APP_PORT) \
+		--source-group $$SG_LAMBDA; \
+	aws ec2 authorize-security-group-ingress \
+		--group-id $SG_ECR_ID \
+		--protocol tcp \
+		--port 443 \
+		--source-group $SG_ECS_ID
 
 register-task-definition:
 	set -o allexport && source ./.env.participant && source ./.env && envsubst < .github/ecs/task-def.template.json > ./.github/ecs/task-def.json

--- a/Makefile
+++ b/Makefile
@@ -206,8 +206,10 @@ create-vpc:
 		--output text); \
 	aws ec2 modify-vpc-attribute \
 		--vpc-id $$VPC_ID \
-		--enable-dns-support '{\"Value\": true}' \
-		--enable-dns-hostnames "{\"Value\":true}"; \
+		--enable-dns-support '{"Value": true}'; \
+	aws ec2 modify-vpc-attribute \
+		--vpc-id $$VPC_ID \
+		--enable-dns-hostnames '{"Value":true}'; \
 	SUBNET1_ID=$$(aws ec2 create-subnet --vpc-id $$VPC_ID --cidr-block $(SUBNET1_CIDR) \
 				--availability-zone $(AZ1) --query 'Subnet.SubnetId' --output text); \
 	SUBNET2_ID=$$(aws ec2 create-subnet --vpc-id $$VPC_ID --cidr-block $(SUBNET2_CIDR) \

--- a/Makefile
+++ b/Makefile
@@ -198,9 +198,15 @@ create-vpc:
 	. ./scripts/assume-role.sh \
 			--role-name $(VPC_ROLE_NAME) \
 			--profile admin; \
-	VPC_ID=$$(aws ec2 create-vpc --cidr-block $(VPC_CIDR) \
-			--region $(MY_AWS_REGION) --query 'Vpc.VpcId' --output text); \
-	aws ec2 modify-vpc-attribute --vpc-id $$VPC_ID --enable-dns-hostnames "{\"Value\":true}"; \
+	VPC_ID=$$(aws ec2 create-vpc \
+		--cidr-block $(VPC_CIDR) \
+		--region $(MY_AWS_REGION) \
+		--query 'Vpc.VpcId' \
+		--output text); \
+	aws ec2 modify-vpc-attribute \
+		--vpc-id $$VPC_ID \
+		--enable-dns-support '{\"Value\": true}' \
+		--enable-dns-hostnames "{\"Value\":true}"; \
 	SUBNET1_ID=$$(aws ec2 create-subnet --vpc-id $$VPC_ID --cidr-block $(SUBNET1_CIDR) \
 				--availability-zone $(AZ1) --query 'Subnet.SubnetId' --output text); \
 	SUBNET2_ID=$$(aws ec2 create-subnet --vpc-id $$VPC_ID --cidr-block $(SUBNET2_CIDR) \

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ init_admin:
 		make --no-print-directory -s crate-security-group)); \
 	SG_LAMBDA=$${VARS[0]}; \
 	SG_ECS=$${VARS[1]}; \
+	SG_ECR=$${VARS[2]}; \
 	SG_LAMBDA=$$SG_LAMBDA \
 	SG_ECS=$$SG_ECS \
 	make --no-print-directory -s create-security-rule; \
@@ -218,12 +219,24 @@ crate-security-group:
 		--role-name $(VPC_ROLE_NAME) \
 		--profile admin; \
 	SG_LAMBDA=$$(aws ec2 create-security-group \
-		--group-name $(SG_LAMBDA_NAME) --description "Lambda outbound to ECS only" \
-		--vpc-id $$VPC_ID --query 'GroupId' --output text); \
+		--group-name $(SG_LAMBDA_NAME) \
+		--description "Lambda outbound to ECS only" \
+		--vpc-id $$VPC_ID \
+		--query 'GroupId' \
+		--output text); \
 	SG_ECS=$$(aws ec2 create-security-group \
-		--group-name $(SG_ECS_NAME) --description "ECS inbound from Lambda" \
-		--vpc-id $$VPC_ID --query 'GroupId' --output text); \
-	echo "$$SG_LAMBDA $$SG_ECS"
+		--group-name $(SG_ECS_NAME) \
+		--description "ECS inbound from Lambda" \
+		--vpc-id $$VPC_ID \
+		--query 'GroupId' \
+		--output text); \
+	SG_ECR_ID=$$(aws ec2 create-security-group \
+		--group-name $(SG_ECR_NAME) \
+		--description "ECR VPC endpoint SG" \
+		--vpc-id $$VPC_ID \
+		--query 'GroupId' \
+		--output text); \
+	echo "$$SG_LAMBDA $$SG_ECS $$SG_ECR_ID"
 
 create-security-rule:
 	. ./scripts/assume-role.sh \

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ init_admin:
 	SUBNET2_ID=$${VARS[2]}; \
 	VARS=($$( \
 		VPC_ID=$${VPC_ID} \
-		make --no-print-directory -s crate-security-group)); \
+		make --no-print-directory -s create-security-group)); \
 	SG_LAMBDA=$${VARS[0]}; \
 	SG_ECS=$${VARS[1]}; \
 	SG_ECR=$${VARS[2]}; \
@@ -214,7 +214,7 @@ create-vpc:
 				--availability-zone $(AZ2) --query 'Subnet.SubnetId' --output text); \
 	echo "$$VPC_ID $$SUBNET1_ID $$SUBNET2_ID"
 
-crate-security-group:
+create-security-group:
 	. ./scripts/assume-role.sh \
 		--role-name $(VPC_ROLE_NAME) \
 		--profile admin; \

--- a/Makefile
+++ b/Makefile
@@ -364,7 +364,7 @@ create-endpoint:
   	RTB_IDS=$$(aws ec2 describe-route-tables \
   		--filters \
     	"Name=vpc-id,Values=$$VPC_ID" \
-    	"Name=association.subnet-id,Values=$$SUBNET1_ID,$$SUBNET2_ID" \
+    	"Name=association.main,Values=true" \
   		--query 'RouteTables[].RouteTableId' --output text); \
 	aws ec2 create-vpc-endpoint \
 		--vpc-id $$VPC_ID \


### PR DESCRIPTION
# Why

* ECSタスクがプライベートサブネット内からECRのプライベートレジストリ（API/DKR）へアクセスし、コンテナイメージをプルできるようにする必要がある。
* インターネットゲートウェイ経由ではなく、VPCエンドポイント経由でセキュアかつ高速にECRへ接続したい。

# What

* VPCでDNSホスト名（enable-dns-hostnames）とDNS解決（enable-dns-support）を有効化
* ECR用のセキュリティグループを新規作成
* ECRセキュリティグループにHTTPS（TCP/443）を許可するインバウンド／アウトバウンドルールを追加
* スクリプト内のタイポ（`crate-security-group` → `create-security-group`）を修正
* VPCエンドポイント（com.amazonaws.<region>.ecr.api, com.amazonaws.<region>.ecr.dkr）を作成するMakeターゲットを追加
* DNS解決で誤ってパブリックECRへ接続してしまう問題を修正
* S3用インターフェイスエンドポイントにルートテーブルがアタッチされない問題を修正

# Result

以下を実行後、プライベートサブネット内のECSタスクからVPCエンドポイント経由でECRイメージを正常にプルできることを確認した。

```bash
make init_admin
make init_mac
```
