### PR TITLE
feat: :zap: Makeで作成した./.github/ecs/task-def.jsonを削除

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,6 +286,7 @@ register-task-definition:
 		--query 'taskDefinition.taskDefinitionArn' \
 		--output text \
 		--region ${MY_AWS_REGION};
+	rm ./.github/ecs/task-def.json
 
 push_aws_parameters:
 	. ./scripts/assume-role.sh \


### PR DESCRIPTION
### Why

* `.github/ecs/task-def.json` は `make` コマンドによって自動生成されるファイルであり、リポジトリ保持する必要がない。
* リポジトリのクリーンアップと、不要なファイルの管理を防ぐため、当該ファイルを削除する。

### What

* make実行後に`.github/ecs/task-def.json` ファイルをリポジトリから削除されるように追記。

### Result

* `make` コマンドを実行することで、`.github/ecs/task-def.json` が自動的に生成されることを確認。
* リポジトリ内に不要なファイルが存在しないことを確認。