### PR TITLE
fix: :bug: TARGET_PATHSが空になるバグを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Build payload.json
         id: build-payload
         run: |
-          IFS=',' read -ra paths <<< "${{ env.TARGET_PATHS }}"
+          IFS=',' read -ra paths <<< "${{ secrets.TARGET_PATHS }}"
           urls=()
           for p in "${paths[@]}"; do
             [[ "$p" != /* ]] && p="/$p"


### PR DESCRIPTION
# Why

* `TARGET_PATHS` が空になるバグが発生していたため、GitHub Actions の処理が正しく実行されない問題があった。

# What

* `TARGET_PATHS` の宣言方法に誤りがあったため修正。

# Result
動作未確認