### PR TITLE
fix: :bug: LIGHTHOUSE_FUNCTION_NAMEが空になるバグを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,7 +114,7 @@ jobs:
         uses: gagoar/invoke-aws-lambda@v3
         with:
           region: ${{ env.MY_AWS_REGION }}
-          function-name: ${{ env.LIGHTHOUSE_FUNCTION_NAME }}
+          function-name: ${{ secrets.LIGHTHOUSE_FUNCTION_NAME }}
           payload: ${{ steps.build-payload.outputs.payload }}
           timeout: 660
 


### PR DESCRIPTION
# Why

* `LIGHTHOUSE_FUNCTION_NAME` が空になるバグが発生していたため、GitHub Actions の処理が正しく実行されない問題があった。

# What

* `LIGHTHOUSE_FUNCTION_NAME` の宣言方法に誤りがあったため修正。

# Result
動作未確認