### PR TITLE
fix: :bug: Invoke lighthouse lambdaがAWSの認証情報を環境変数から読み取れない問題を解決

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,7 @@ jobs:
 
       # AWS の認証情報を設定
       - name: Configure AWS credentials
+        id: awscreds
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.IAM_ROLE_NAME }}
@@ -113,11 +114,14 @@ jobs:
         id: invoke-lambda
         uses: gagoar/invoke-aws-lambda@v3
         with:
+          AWS_ACCESS_KEY_ID: ${{ steps.awscreds.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.awscreds.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.awscreds.outputs.aws-session-token }}
           Region: ${{ env.MY_AWS_REGION }}
           FunctionName: ${{ secrets.LIGHTHOUSE_FUNCTION_NAME }}
           Payload: ${{ steps.build-payload.outputs.payload }}
           HTTP_TIMEOUT: 660000
-          LogType:   RequestResponse 
+          LogType: RequestResponse
 
       # レスポンスをログ表示
       - name: Show response


### PR DESCRIPTION
# Why

* GitHub ActionsでAWS Lambdaを呼び出す際に、AWSの認証情報（`AWS_ACCESS_KEY_ID`、`AWS_SECRET_ACCESS_KEY`、`AWS_SESSION_TOKEN`）が環境変数として正しく設定されておらず、Lambda関数の実行に失敗していた。

# What

* GitHub Actionsのワークフローファイルを修正し、`aws-actions/configure-aws-credentials`アクションを利用して、`AWS_ACCESS_KEY_ID`、`AWS_SECRET_ACCESS_KEY`、`AWS_SESSION_TOKEN`を環境変数として正しく設定されるように変更した。
* 具体的には、AssumeRoleした結果の一時的認証情報を、後続ステップで参照可能にした。

# Result

動作未確認
