### PR TITLE
fix: :bug: Invoke lighthouse lambdaがAWSの認証情報を環境変数から読み取れない問題を解決

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.IAM_ROLE_NAME }}
           aws-region: ${{ env.MY_AWS_REGION }}
+          output-credentials: true
 
       # ECR にログイン
       - name: Login to Amazon ECR
@@ -114,9 +115,9 @@ jobs:
         id: invoke-lambda
         uses: gagoar/invoke-aws-lambda@v3
         with:
-          AWS_ACCESS_KEY_ID: ${{ steps.awscreds.outputs.aws-access-key-id }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.awscreds.outputs.aws-secret-access-key }}
-          AWS_SESSION_TOKEN: ${{ steps.awscreds.outputs.aws-session-token }}
+          AWS_ACCESS_KEY_ID: ${{ steps.awscreds.outputs['aws-access-key-id'] }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.awscreds.outputs['aws-secret-access-key'] }}
+          AWS_SESSION_TOKEN: ${{ steps.awscreds.outputs['aws-session-token'] }}
           Region: ${{ env.MY_AWS_REGION }}
           FunctionName: ${{ secrets.LIGHTHOUSE_FUNCTION_NAME }}
           Payload: ${{ steps.build-payload.outputs.payload }}


### PR DESCRIPTION
# Why

* LighthouseをAWS Lambda上で実行する際、AWSの認証情報（アクセスキーやシークレットキー）を受け取れない問題が発生。
* この問題により、Lambda関数がAWSリソースにアクセスできず、Lighthouseの自動実行が失敗していた。

# What

* `output-credentials: true`でマスクされた認証情報をstepに出力
* ハイフンが含まれる変数を読み取るためにキーを活用


# Result

