### PR TITLE
fix: :bug: output-credentials: trueが動作詞ない問題に対応

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
       # AWS の認証情報を設定
       - name: Configure AWS credentials
         id: awscreds
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.IAM_ROLE_NAME }}
           aws-region: ${{ env.MY_AWS_REGION }}


### PR DESCRIPTION
# Why

* `output-credentials: true` を設定することで、認証情報を出力することが期待されていたが、想定通りに動作していなかった。

# What

* `output-credentials: true` が現行のaws-actions/configure-aws-credentialsのv2で使用できる情報が見当たらなかったため、aws-actions/configure-aws-credentialsのバージョンを4へアップデート

# Result

動作未確認
