### PR TITLE
fix: :bug: gagoar/invoke-aws-lambdaのパラメータを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,7 +134,7 @@ jobs:
           FunctionName: ${{ secrets.LIGHTHOUSE_FUNCTION_NAME }}
           Payload: ${{ steps.build-payload.outputs.payload }}
           HTTP_TIMEOUT: 660000
-          LogType: RequestResponse
+          LogType: None
 
       # レスポンスをログ表示
       - name: Show response


### PR DESCRIPTION
# Why
* `LogType` の設定が不適切であった。

# What

* `LogType` の値を `None` に修正し、不要なログ出力を抑制。

# Result
動作未確認
